### PR TITLE
insert some casts to eliminate some warning messages from gcc

### DIFF
--- a/libraries/AStar32U4Prime/FastGPIO.h
+++ b/libraries/AStar32U4Prime/FastGPIO.h
@@ -71,17 +71,17 @@ namespace FastGPIO
 
         volatile uint8_t * pin() const
         {
-            return (volatile uint8_t *)pinAddr;
+            return (volatile uint8_t *)(int)pinAddr;
         }
 
         volatile uint8_t * port() const
         {
-            return (volatile uint8_t *)portAddr;
+            return (volatile uint8_t *)(int)portAddr;
         }
 
         volatile uint8_t * ddr() const
         {
-            return (volatile uint8_t *)ddrAddr;
+            return (volatile uint8_t *)(int)ddrAddr;
         }
     } IOStruct;
     /** @endcond */

--- a/libraries/AStar32U4Prime/FastGPIO.h
+++ b/libraries/AStar32U4Prime/FastGPIO.h
@@ -71,17 +71,17 @@ namespace FastGPIO
 
         volatile uint8_t * pin() const
         {
-            return (volatile uint8_t *)(int)pinAddr;
+            return (volatile uint8_t *)(uint16_t)pinAddr;
         }
 
         volatile uint8_t * port() const
         {
-            return (volatile uint8_t *)(int)portAddr;
+            return (volatile uint8_t *)(uint16_t)portAddr;
         }
 
         volatile uint8_t * ddr() const
         {
-            return (volatile uint8_t *)(int)ddrAddr;
+            return (volatile uint8_t *)(uint16_t)ddrAddr;
         }
     } IOStruct;
     /** @endcond */


### PR DESCRIPTION
The warning was about casting a short int to a longer pointer.
